### PR TITLE
Added bootstrap scss import + area for overloading

### DIFF
--- a/debug.log
+++ b/debug.log
@@ -1,1 +1,2 @@
 [1008/083350.981:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
+[1008/101915.297:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2632,6 +2632,11 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
+    "bootstrap": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.5.2.tgz",
+      "integrity": "sha512-vlGn0bcySYl/iV+BGA544JkkZP5LB3jsmkeKLFQakCOwCM3AOk7VkldBz4jrzSe+Z0Ezn99NVXa1o45cQY4R6A=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@angular/router": "~10.0.4",
     "@ngx-translate/core": "^13.0.0",
     "@ngx-translate/http-loader": "^6.0.0",
+    "bootstrap": "^4.5.2",
     "rxjs": "~6.5.5",
     "tslib": "^2.0.0",
     "zone.js": "~0.10.3"

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,6 @@
     <title>Accommodations</title>
     <base href="/">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
     <link rel="icon" type="image/x-icon" href="favicon.ico">
   </head>
   <body class="h-100 w-100">

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,1 +1,11 @@
 /* You can add global styles to this file, and also import other style files */
+
+// Add our overrides for the bootstrap variables here
+// Example:
+// $primary: #fff540;
+
+
+// End overloading section
+
+// Imports for style files
+@import './node_modules/bootstrap/scss/bootstrap.scss';


### PR DESCRIPTION
A small but necessary feature to import the bootstrap scss file instead of using the CDN. 
- removed the CDN link in the HTML
- added bootstrap to the dependencies
- added sass import for the Bootstrap sass file